### PR TITLE
Fixed the link of retry one-liner in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install:
 retry is a shell script, so drop it somewhere and make sure it's added to your \$PATH. Or you can use the following one-liner:
 
 ```Shell
-curl -SsfL -o /usr/local/bin/retry https://raw.githubusercontent.com/owncloud-ops/retry/master/retry && chmod +x /usr/local/bin/retry"
+curl -SsfL -o /usr/local/bin/retry https://raw.githubusercontent.com/owncloud-ci/retry/master/retry && chmod +x /usr/local/bin/retry
 ```
 
 ## Usage


### PR DESCRIPTION
```console
curl -SsfL -o /usr/local/bin/retry https://raw.githubusercontent.com/owncloud-ops/retry/master/retry && chmod +x /usr/local/bin/retry
```
In the readme file's retry one-liner: the link to retry content is wrong, retry is not in `owncloud-ops`, it is in `owncloud-ci`.
Fixed with
```console
curl -SsfL -o /usr/local/bin/retry https://raw.githubusercontent.com/owncloud-ci/retry/master/retry && chmod +x /usr/local/bin/retry
```